### PR TITLE
Change Guid from sample Guid

### DIFF
--- a/AmpHealthcheck.cs
+++ b/AmpHealthcheck.cs
@@ -9,7 +9,7 @@ using Umbraco.Core.Services;
 
 namespace Umbraco.Web.HealthCheck.Checks.SEO
 {
-    [HealthCheck("3A482719-3D90-4BC1-B9F8-910CD9CF5B32", "AmpValidation",
+    [HealthCheck("17e136d8-10f5-4a85-825c-dcae2a9b4068", "AmpValidation",
     Description = "Check AMP validation on pages",
     Group = "SEO")]
     public class AmpHealthcheck : HealthCheck


### PR DESCRIPTION
Change the Guid to something unique instead of the from the sample Guid the Robots Health Checker sample uses on [Our Umbraco: Extending Healthcheck](https://our.umbraco.org/Documentation/Extending/Healthcheck), so that people don't duplicate in the SEO group if they include the Robots checker and then see duplicated behaviour (I just happened to do this to realise, feel free to change my generated Guid).